### PR TITLE
Allow different nvidia overclocks

### DIFF
--- a/nvidia/overclock.py
+++ b/nvidia/overclock.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""A module that execute commands to overclock nvidia chips.
+
+Prequisites: overclock values should be present in automine/overclock.json
+
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import subprocess
+import sys
+
+
+_LIST_GPUS_CMD = "nvidia-smi --query-gpu=name,index --format=csv,noheader"
+
+
+def _sibling_path(name):
+    """Compute path of file relative to this module."""
+    here = os.path.dirname(os.path.join(os.getcwd(), __file__))
+    return os.path.normpath(os.path.join(here, name))
+
+
+def perform_overclock(cfgs):
+    """Perform the overclock."""
+    gpus_with_index = subprocess.check_output(_LIST_GPUS_CMD.split())
+    one_gpu_script = _sibling_path('overclock_one_gpu.sh')
+    for (name, index) in [l.split(',') for l in gpus_with_index.splitlines()]:
+        index = index.strip()
+        if not name in cfgs:
+            print("Skipped {0} at #{1}, no config set for it".format(name, index))
+        else:
+            print("Overclocking {0} at #{1}".format(name, index))
+            child_env = dict(os.environ)
+            child_env['NVD_GPU_INDEX'] = index
+            for name, value in iter(cfgs[name].items()):
+                child_env["NVD_{0}".format(name.upper())] = str(value)
+            print(subprocess.check_output(one_gpu_script,
+                                          executable='/bin/bash',
+                                          env=child_env,
+                                          shell=True))
+
+
+def main():
+    """The comamnd line entry point """
+    cfg_path = _sibling_path('../overclock.json')
+    if not os.path.exists(cfg_path):
+        print("No overclock.json at {}, exiting".format(cfg_path))
+        sys.exit(1)
+    try:
+        cfg_dict = json.load(open(cfg_path))
+        cfgs = cfg_dict.get('nvidia')
+        if not isinstance(cfgs, dict):
+            raise ValueError("Did not find overclocks in {}".format(cfg_path))
+        print("configuration found at {0}".format(cfg_path))
+        perform_overclock(cfgs)
+    except ValueError as err:
+        print("Error overclocking using the cfg: {0}, exiting".format(cfg_path))
+        print(err)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/nvidia/overclock.sh
+++ b/nvidia/overclock.sh
@@ -33,18 +33,9 @@ perform_overclock() {
 
     # Update GPUs
     local max_card_index=$(expr $(nvidia-smi -L | wc -l) - 1)
-    local settings_cmd='/usr/bin/nvidia-settings -a'
-    for i in $(seq 0 $max_card_index)
+    for NVD_GPU_INDEX in $(seq 0 $max_card_index)
     do
-        echo "Updating card $i power_level=$NVD_POWER_LEVEL fan_speed=$NVD_FAN_SPEED"
-        echo "                 GPU Clock offset=$NVD_CLOCK_OFFSET Memory Offset=$NVD_MTR_OFFSET"
-        nvidia-smi -i ${i} -pm 1
-        nvidia-smi -i ${i} -pl $NVD_POWER_LEVEL
-        ${settings_cmd} [gpu:${i}]/GPUPowerMizerMode=1
-        ${settings_cmd} [gpu:${i}]/GPUFanControlState=1
-        ${settings_cmd} [fan:${i}]/GPUTargetFanSpeed=$NVD_FAN_SPEED
-        ${settings_cmd} [gpu:${i}]/GPUGraphicsClockOffset[3]=${NVD_CLOCK_OFFSET}
-        ${settings_cmd} [gpu:${i}]/GPUMemoryTransferRateOffset[3]=${NVD_MTR_OFFSET}
+        source $SCRIPT_DIR/overclock_one_gpu.sh
     done
 }
 

--- a/nvidia/overclock_one_gpu.sh
+++ b/nvidia/overclock_one_gpu.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Overclocks a single Nvidia GPU (nvidia-smi and nvidia-settings)
+#
+# Prequisites: should be run as root
+#              needs a X display running, and the DISPLAY variable set
+#
+# Usage:
+# ------
+# Intended to be used from overclock.sh and overclock.py
+
+perform_one_overclock() {
+    NVD_APPLICATION_SETTINGS=${NVD_APPLICATION_SETTINGS:=''}
+
+    set -u  # fail if any required NVD environment variables is not set
+    local settings_cmd='/usr/bin/nvidia-settings -a'
+    echo "Updating card $NVD_GPU_INDEX"
+    echo "power_level=$NVD_POWER_LEVEL fan_speed=$NVD_FAN_SPEED"
+    echo "GPU Clock offset=$NVD_CLOCK_OFFSET Memory Offset=$NVD_MTR_OFFSET"
+
+    nvidia-smi -i ${NVD_GPU_INDEX} -pm 1
+    nvidia-smi -i ${NVD_GPU_INDEX} -pl $NVD_POWER_LEVEL
+    [ -n ${NVD_APPLICATION_SETTINGS} ] && nvidia-smi -i ${NVD_GPU_INDEX} -ac ${NVD_APPLICATION_SETTINGS}
+    ${settings_cmd} [gpu:${NVD_GPU_INDEX}]/GPUPowerMizerMode=1
+    ${settings_cmd} [gpu:${NVD_GPU_INDEX}]/GPUFanControlState=1
+    ${settings_cmd} [fan:${NVD_GPU_INDEX}]/GPUTargetFanSpeed=$NVD_FAN_SPEED
+    ${settings_cmd} [gpu:${NVD_GPU_INDEX}]/GPUGraphicsClockOffset[3]=${NVD_CLOCK_OFFSET}
+    ${settings_cmd} [gpu:${NVD_GPU_INDEX}]/GPUMemoryTransferRateOffset[3]=${NVD_MTR_OFFSET}
+    set +u
+}
+
+perform_one_overclock

--- a/nvidia/run_ethminer.sh
+++ b/nvidia/run_ethminer.sh
@@ -18,31 +18,15 @@ this_dir() {
 
 SCRIPT_DIR=$(this_dir)
 source $(dirname $SCRIPT_DIR)/cfg.sh
-[[ -z $WALLET ]] && {
-    echo "WALLET not defined in the environment"
-    exit 1
-}
-[[ -z $WORKER ]] && {
-    echo "WORKER not defined in the environment"
-    exit 1
-}
-[[ -z $MAIN_POOL ]] && {
-    echo "MAIN_POOL not defined in the environment"
-    exit 1
-}
-[[ -z $FALLBACK_POOL ]] && {
-    echo "FALLBACK_POOL not defined in the environment"
-    exit 1
-}
-MINER_BIN=$HOME/bin/ethminer
+set -u
+echo "Mining to ${WALLET}.${WORKER} at ${MAIN_POOL} || ${FALLBACK_POOL}"
+set +u
 
-set -x
-$MINER_BIN -U \
+$HOME/bin/ethminer -U \
     -S ${MAIN_POOL} \
     -FS ${FALLBACK_POOL}  \
     -O "$WALLET"."$WORKER" \
     --cuda-grid-size 16384 \
     --cuda-block-size 128 \
-    --cuda-streams 4 \
+    --cuda-parallel-hash 8 \
     --farm-recheck 200
-set +x

--- a/rsync_scripts.sh
+++ b/rsync_scripts.sh
@@ -3,4 +3,5 @@
 source ssh_ensure_env.sh
 ssh ${SSH_USER} mkdir -p \~/bin
 cp cfg/$RIG_IP.sh cfg.sh
+[ -f cfg/$RIG_IP.overclock.json ] && cp cfg/$RIG_IP.overclock.json overclock.json
 rsync -avz --del --exclude=cfg/* . ${SSH_USER}:~/bin/automine


### PR DESCRIPTION
Adds nvidia/overclock.py.

This does a similar thing to nvidia/overclock.sh, but is configured by per-rig
json file that allows the overclocks to differ per rig and nvidia card name.