### PR TITLE
Allow the value of cuda-parallel-hash flag to be configured

### DIFF
--- a/cfg/127.0.0.1.sample.sh
+++ b/cfg/127.0.0.1.sample.sh
@@ -25,6 +25,10 @@ WORKER='FILL_THIS_IN'
 MAIN_POOL=asia1.ethermine.org:4444
 FALLBACK_POOL=us2.ethermine.org:4444
 
+# Optionally, choose the value of --cuda-parallel-hash flag.  This can have an
+# an effect on the hash rate when mining with Nvidia cards
+CUDA_PARALLEL_HASH=4
+
 # NVIDIA overclock settings
 # These are sample overclocking parameters for Nvidia cards
 # Used in /nvidia/overclock.sh

--- a/nvidia/run_ethminer.sh
+++ b/nvidia/run_ethminer.sh
@@ -22,11 +22,12 @@ set -u
 echo "Mining to ${WALLET}.${WORKER} at ${MAIN_POOL} || ${FALLBACK_POOL}"
 set +u
 
-$HOME/bin/ethminer -U \
+$HOME/bin/ethminer \
     -S ${MAIN_POOL} \
     -FS ${FALLBACK_POOL}  \
     -O "$WALLET"."$WORKER" \
+    -U \
     --cuda-grid-size 8192
     --cuda-block-size 64 \
-    --cuda-parallel-hash 8 \
+    --cuda-parallel-hash ${CUDA_PARALLEL_HASH:-8} \
     --farm-recheck 200


### PR DESCRIPTION
This makes it possible to use different values of the cuda-parallel-hash flag on
different rigs.