### PR TITLE
Make :0 the default value of DISPLAY

### DIFF
--- a/nvidia/overclock.sh
+++ b/nvidia/overclock.sh
@@ -6,7 +6,8 @@
 #
 # Usage:
 # ------
-# $ sudo DISPLAY=:0 $HOME/bin/automine/nvidia/overclock.sh
+# $ sudo $HOME/bin/automine/nvidia/overclock.sh  # uses default DISPLAY of :0
+# $ sudo DISPLAY=:1 $HOME/bin/automine/nvidia/overclock.sh # choose a different display 
 
 this_dir() {
     local script_path="${BASH_SOURCE[0]}"

--- a/nvidia/overclock_one_gpu.sh
+++ b/nvidia/overclock_one_gpu.sh
@@ -2,14 +2,16 @@
 # Overclocks a single Nvidia GPU (nvidia-smi and nvidia-settings)
 #
 # Prequisites: should be run as root
-#              needs a X display running, and the DISPLAY variable set
+#              needs a X display running
 #
 # Usage:
 # ------
 # Intended to be used from overclock.sh and overclock.py
+# DISPLAY takes its value from the environment but defaults to ':0'
 
 perform_one_overclock() {
     NVD_APPLICATION_SETTINGS=${NVD_APPLICATION_SETTINGS:=''}
+    export DISPLAY=${DISPLAY:=':0'}
 
     set -u  # fail if any required NVD environment variables is not set
     local settings_cmd='/usr/bin/nvidia-settings -a'


### PR DESCRIPTION
This makes it unnecessary to set it when running the overclock scripts