### PR TITLE
Make triggering off log scans configurable

### DIFF
--- a/common/automine.service
+++ b/common/automine.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Launch/Relaunch the screen session that runs the miner
+Description=the screen session that runs the miner
 
 [Service]
 Type=forking

--- a/common/automine_triggers.path
+++ b/common/automine_triggers.path
@@ -1,9 +1,10 @@
 [Unit]
-Description=Detect when any trigger file is changed
+Description=a mining trigger file was changed
 
 [Path]
 PathChanged=%h/var/automine/triggers/switched_to_fallback.txt
 PathChanged=%h/var/automine/triggers/detected_launch_failure.txt
+PathChanged=%h/var/automine/triggers/detected_illegal_memory_access.txt
 
 [Install]
 WantedBy=default.target

--- a/common/scan_log.json
+++ b/common/scan_log.json
@@ -1,0 +1,5 @@
+{
+    "Solution found; Submitting to ${FALLBACK_POOL}": "${AUTOMINE_ALERT_DIR}/switched_to_fallback.txt",
+    "unspecified launch failure" : "${AUTOMINE_ALERT_DIR}/detected_launch_failure.txt",
+    "an illegal memory access": "${AUTOMINE_ALERT_DIR}/detected_illegal_memory_access.txt"
+}

--- a/common/scan_log.py
+++ b/common/scan_log.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""A module that scans standard input for errors.
+
+The log substrings to test the input for are configured in by a json file that
+maps them to the path of the trigger file to be updated when they are detected
+
+"""
+
+from __future__ import print_function
+
+from datetime import datetime
+import json
+import os
+import sys
+
+
+def _sibling_path(name):
+    """Compute path of file relative to this module."""
+    here = os.path.dirname(os.path.join(os.getcwd(), __file__))
+    return os.path.normpath(os.path.join(here, name))
+
+
+def read_cfg(cfg_path):
+    """Load the error cfg"""
+    try:
+        fallback_pool = os.environ['FALLBACK_POOL']
+        automine_alert_dir = os.environ['AUTOMINE_ALERT_DIR']
+        raw_dict = json.load(open(cfg_path))
+        cfg_dict = {}
+        for key, value in iter(raw_dict.items()):
+            new_key = key.replace("${FALLBACK_POOL}", fallback_pool)
+            new_value = value.replace("${AUTOMINE_ALERT_DIR}", automine_alert_dir)
+            cfg_dict[new_key] = new_value
+        return cfg_dict
+    except KeyError as err:
+        raise ValueError('scan_log: Environment did not specify {}'.format(err))
+
+
+def _print(some_text):
+    with open("/tmp/scan_log.out", "a") as fh:
+        print(some_text, file=fh)
+
+
+_MAX_COUNT = 6
+
+
+def perform_scan(src, error_cfg):
+    """Scan lines of input for the configured errors"""
+    count = 0
+    while True:
+        a_line = src.readline()
+        if not a_line:  # EOF
+            break
+        if count < _MAX_COUNT:  # print something to indicate scan is running ok
+            count += 1
+            if count == _MAX_COUNT:
+                _print("scan_log: scanned up to {} lines OK".format(count))
+
+        # scan for the configured lines, halting the scan once an error occurs
+        now = datetime.now()
+        for subst, trigger_path in iter(error_cfg.items()):
+            if a_line.find(subst) == -1:
+                continue
+            open(trigger_path, 'a').write(now.strftime('%Y/%m/%D::%H:%M:%S\n'))
+            _print("scan_log: done, wrote to {} at {}".format(trigger_path, now))
+            return  # exit once any error occurs
+
+def main():
+    """The comamnd line entry point """
+    cfg_path = _sibling_path('scan_log.json')
+    if not os.path.exists(cfg_path):
+        _print("No scan_log.json at {}, exiting".format(cfg_path))
+        sys.exit(1)
+    try:
+        perform_scan(sys.stdin, read_cfg(cfg_path))
+        sys.exit(1)  # indicate that the src program errored
+    except ValueError as err:
+        _print(str(err))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/nvidia/run_ethminer.sh
+++ b/nvidia/run_ethminer.sh
@@ -37,6 +37,11 @@ detected_launch_failure() {
         && echo "$(date +%Y/%m/%d::%H:%M:%S)" >> $AUTOMINE_ALERT_DIR/detected_launch_failure.txt
 }
 
+detected_illegal_memory_access() {
+    grep -q "an illegal memory access" \
+        && echo "$(date +%Y/%m/%d::%H:%M:%S)" >> $AUTOMINE_ALERT_DIR/detected_illegal_memory_access.txt
+}
+
 $HOME/bin/ethminer \
     -S ${MAIN_POOL} \
     -FS ${FALLBACK_POOL}  \
@@ -46,4 +51,4 @@ $HOME/bin/ethminer \
     --cuda-block-size 64 \
     --cuda-parallel-hash ${CUDA_PARALLEL_HASH:-8} \
     --farm-recheck 200 \
-        | tee >(switched_to_fallback) >(detected_launch_failure)
+        | tee >(switched_to_fallback) >(detected_launch_failure) >(detected_illegal_memory_access)


### PR DESCRIPTION
Added scan_log.py which will read the output of ethminer in a fifo
- this makes it easier to add new triggers as whenever they are identified

Also
- added another trigger to restart when "illegal memory access" warnings occur