### PR TITLE
Update log scanning to scan for unknown errors

### DIFF
--- a/common/automine_triggers.path
+++ b/common/automine_triggers.path
@@ -5,6 +5,7 @@ Description=a mining trigger file was changed
 PathChanged=%h/var/automine/triggers/switched_to_fallback.txt
 PathChanged=%h/var/automine/triggers/detected_launch_failure.txt
 PathChanged=%h/var/automine/triggers/detected_illegal_memory_access.txt
+PathChanged=%h/var/automine/triggers/unknown_crash.txt
 
 [Install]
 WantedBy=default.target

--- a/common/scan_log.json
+++ b/common/scan_log.json
@@ -1,5 +1,6 @@
 {
     "Solution found; Submitting to ${FALLBACK_POOL}": "${AUTOMINE_ALERT_DIR}/switched_to_fallback.txt",
     "unspecified launch failure" : "${AUTOMINE_ALERT_DIR}/detected_launch_failure.txt",
-    "an illegal memory access": "${AUTOMINE_ALERT_DIR}/detected_illegal_memory_access.txt"
+    "an illegal memory access": "${AUTOMINE_ALERT_DIR}/detected_illegal_memory_access.txt",
+    "0.00MH/s": "${AUTOMINE_ALERT_DIR}/unknown_crash.txt"
 }


### PR DESCRIPTION
Unknown errors are detected by looking for 0.00MH/s in the output

This is necessary because the current ethminer error log lines are not
necessarily written to STDOUT, only to STDERR. However, STDERR cannot be scanned
as lots it appears to contain a lot of non-ascii garbage that breaks the
scanning program

This makes some of the other configured scans  unreliable.