### PR TITLE
Update the sample cfg to show a required environment assignment

### DIFF
--- a/cfg/127.0.0.1.sample.sh
+++ b/cfg/127.0.0.1.sample.sh
@@ -12,6 +12,11 @@ RIG_TYPE='FILL_THIS_IN'
 # For installing the nvidia driver
 CUDA_VERSION=ubuntu1604_8.0.61-1
 
+# Required by the log scanning utility that used in run_ethminer
+#
+# Don't modify this, it really needs to be set with this value here!
+AUTOMINE_ALERT_DIR=$HOME/var/automine/triggers
+
 # Ethminer values
 # Your ETH wallet
 WALLET='FILL_THIS_IN'


### PR DESCRIPTION
So far, this is the only reliable way to ensure that AUTOMINE_ALERT_DIR is
exported when the scan_log.py is used within run_ethminer.sh

The sample cfg is updated to reflect this.

N.B:
It is *necessary* to make this change to existing rig configurations.