### PR TITLE
Enable overclock triggering

### DIFF
--- a/common/automine_overclock.path
+++ b/common/automine_overclock.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=trigger: update the gpu overclocks
+
+[Path]
+PathChanged=/tmp/automine/overclock.json
+
+[Install]
+WantedBy=default.target

--- a/common/automine_overclock.service
+++ b/common/automine_overclock.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=update the gpu overclocks
+Requires=display-manager.service
+After=display-manager.service
+
+[Service]
+Environment="DISPLAY=:0"
+Environment="XAUTHORITY={{$HOME}}/.Xauthority"
+Environment="RIG_TYPE={{$RIG_TYPE}}"
+Environment="USER_HOME={{$HOME}}"
+ExecStart=/bin/bash -c "${USER_HOME}/bin/automine/${RIG_TYPE}/overclock.py /tmp/automine/overclock.json"

--- a/nvidia/overclock_one_gpu.sh
+++ b/nvidia/overclock_one_gpu.sh
@@ -15,9 +15,9 @@ perform_one_overclock() {
 
     set -u  # fail if any required NVD environment variables is not set
     local settings_cmd='/usr/bin/nvidia-settings -a'
-    echo "Updating card $NVD_GPU_INDEX"
-    echo "power_level=$NVD_POWER_LEVEL fan_speed=$NVD_FAN_SPEED"
-    echo "GPU Clock offset=$NVD_CLOCK_OFFSET Memory Offset=$NVD_MTR_OFFSET"
+    printf "GPU #$NVD_GPU_INDEX targets:"
+    printf " power level->$NVD_POWER_LEVEL fan speed->$NVD_FAN_SPEED"
+    printf " clock offset->$NVD_CLOCK_OFFSET memory offset->$NVD_MTR_OFFSET\n"
 
     nvidia-smi -i ${NVD_GPU_INDEX} -pm 1
     nvidia-smi -i ${NVD_GPU_INDEX} -pl $NVD_POWER_LEVEL

--- a/ssh_install_systemd_units.sh
+++ b/ssh_install_systemd_units.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source rsync_scripts.sh
-ssh -t $SSH_USER \~/bin/automine/common/install_systemd_units.sh
+ssh -t $SSH_USER RIG_TYPE=${RIG_TYPE} \~/bin/automine/common/install_systemd_units.sh


### PR DESCRIPTION
After installing this change, this cp

```
cp $HOME/bin/automine/overclock.json /tmp/automine/
```

triggers the nvidia python overclock (as superuser).

It uses a systemd path unit to monitor the target file path for changes,
linked to a systemd service that runs the overclock tool.