### PR TITLE
Add trigger on restart

### DIFF
--- a/common/automine.service
+++ b/common/automine.service
@@ -2,6 +2,7 @@
 Description=the screen session that runs the miner
 
 [Service]
+Environment="RIG_TYPE={{$RIG_TYPE}}"
 Type=forking
 RemainAfterExit=yes
 ExecStart=/bin/bash -c "%h/bin/automine/${RIG_TYPE}/launch_screen_session.sh"

--- a/common/automine_after_reboot.service
+++ b/common/automine_after_reboot.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=the indirect restart of automine after a bad gpu caused a reboot
+Requires=automine.service
+After=automine.service
+
+[Service]
+ExecStartPre=/bin/mkdir -p /tmp/automine
+ExecStart=/bin/bash -c "cp %h/bin/automine/overclock.json /tmp/automine/overclock.json"
+ExecStartPost=/bin/systemctl --user disable automine_after_reboot
+
+[Install]
+WantedBy=default.target

--- a/common/automine_needs_reboot.path
+++ b/common/automine_needs_reboot.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=trigger: a request from an unhealthy gpu for a reboot
+
+[Path]
+PathChanged=%h/var/automine/triggers/failed_gpus.txt
+
+[Install]
+WantedBy=default.target

--- a/common/automine_needs_reboot.service
+++ b/common/automine_needs_reboot.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=a request from an unhealthy gpu for a reboot
+
+[Service]
+ExecStart=/bin/systemctl --user enable automine_after_reboot
+ExecStartPost=/bin/bash -c "date -u +'%Y-%%m-%dT%%H:%M:%SZ' >> %h/var/automine/triggers/reboot_requests.txt"

--- a/common/automine_reboot.path
+++ b/common/automine_reboot.path
@@ -1,0 +1,8 @@
+[Unit]
+Description=trigger: a reboot caused by an unhealthy gpu
+
+[Path]
+PathChanged={{$HOME}}/var/automine/triggers/reboot_requests.txt
+
+[Install]
+WantedBy=default.target

--- a/common/automine_reboot.service
+++ b/common/automine_reboot.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=a reboot caused by an unhealthy gpu
+
+[Service]
+ExecStart=/sbin/reboot

--- a/common/install_systemd_units.sh
+++ b/common/install_systemd_units.sh
@@ -26,13 +26,19 @@ cp_user_systemd_units() {
     local here=$(this_dir)
     local systemd_dir=${HOME}/.config/systemd/user
     mkdir -p $systemd_dir
-    cp -v ${here}/automine.service $systemd_dir
+    sed -e "s|{{\$RIG_TYPE}}|$RIG_TYPE|g" \
+        ${here}/automine.service \
+        | sudo tee $systemd_dir/automine.service
+
     cp -v ${here}/automine_triggers.service $systemd_dir
     cp -v ${here}/automine_triggers.path $systemd_dir
     cp -v ${here}/automine_gpu_health.timer $systemd_dir
     sed -e "s/{{\$RIG_TYPE}}/$RIG_TYPE/g" \
         ${here}/gpu_health.service \
         | sudo tee $systemd_dir/gpu_health.service
+    cp -v ${here}/automine_needs_reboot.path $systemd_dir
+    cp -v ${here}/automine_needs_reboot.service $systemd_dir
+    cp -v ${here}/automine_after_reboot.service $systemd_dir
 }
 
 # Update, then copy the overclock systemd units to the superuser systemd
@@ -51,18 +57,35 @@ install_overclock_systemd_units() {
     mkdir -p /tmp/automine
 }
 
+# Update, then copy the reboot systemd units to the superuser systemd
+# directory
+install_reboot_systemd_units() {
+    local here=$(this_dir)
+    local systemd_dir=/lib/systemd/system
+    sed -e "s|{{\$HOME}}|$HOME|g" \
+        ${here}/automine_reboot.path \
+        | sudo tee $systemd_dir/automine_reboot.path
+    sudo cp -v ${here}/automine_reboot.service $systemd_dir
+    mkdir -p /tmp/automine
+}
+
 # enable the systemd trigger services
-enable_and_start() {
+enable_triggers_and_timers() {
     systemctl --user enable automine_triggers.path
     systemctl --user start automine_triggers.path
+    systemctl --user enable automine_needs_reboot.path
+    systemctl --user start automine_needs_reboot.path
     systemctl --user enable automine_gpu_health.timer
     systemctl --user start automine_gpu_health.timer
     sudo systemctl enable automine_overclock.path
     sudo systemctl start automine_overclock.path
+    sudo systemctl enable automine_reboot.path
+    sudo systemctl start automine_reboot.path
 }
 
 set -e
 cp_user_systemd_units
 enable_user_systemd_services
 install_overclock_systemd_units
-enable_and_start
+install_reboot_systemd_units
+enable_triggers_and_timers

--- a/nvidia/launch_screen_session.sh
+++ b/nvidia/launch_screen_session.sh
@@ -9,13 +9,8 @@ echo 'Starting ethminer in a detached screen...'
 killall -TERM ethminer >/dev/null 2>&1
 kill -TERM `screen -list | grep ethminer | cut -d \. -f 1 | awk {'print $1'}` >/dev/null 2>&1
 
-echo -n "."; sleep 1
-
 # Put a BASH shell on tab 0.  Good for examining a running system
 /usr/bin/screen -AdmS ethminer -t shell bash
-
-# Start a vncserver.  This works because the /etc/X11/xorg.conf is set up to allow headless access
-/usr/bin/screen -S ethminer -X screen -t vncserver x0vncserver -display :0 -passwordfile $HOME/.vnc/passwd
 
 # Run the miner in tab 1
 /usr/bin/screen -S ethminer -X screen -t ethminer $HOME/bin/automine/nvidia/run_ethminer.sh
@@ -29,6 +24,4 @@ echo -n "."; sleep 1
 screen -r -p ethminer
 
 exit 0
-
-
 


### PR DESCRIPTION
This is complicated because automine is a user service that needs to interact
with superuser services to reboot the system.

However, user services cannot depend on system services, so the approach is to
use file triggers to interact between user and system service instead