### PR TITLE
Add a new scan trigger

### DIFF
--- a/common/automine_triggers.path
+++ b/common/automine_triggers.path
@@ -6,6 +6,7 @@ PathChanged=%h/var/automine/triggers/switched_to_fallback.txt
 PathChanged=%h/var/automine/triggers/detected_launch_failure.txt
 PathChanged=%h/var/automine/triggers/detected_illegal_memory_access.txt
 PathChanged=%h/var/automine/triggers/unknown_crash.txt
+PathChanged=%h/var/automine/triggers/cant_submit_not_connected.text
 
 [Install]
 WantedBy=default.target

--- a/common/scan_log.json
+++ b/common/scan_log.json
@@ -2,5 +2,6 @@
     "Solution found; Submitting to ${FALLBACK_POOL}": "${AUTOMINE_ALERT_DIR}/switched_to_fallback.txt",
     "unspecified launch failure" : "${AUTOMINE_ALERT_DIR}/detected_launch_failure.txt",
     "an illegal memory access": "${AUTOMINE_ALERT_DIR}/detected_illegal_memory_access.txt",
-    "0.00MH/s": "${AUTOMINE_ALERT_DIR}/unknown_crash.txt"
+    "0.00MH/s": "${AUTOMINE_ALERT_DIR}/unknown_crash.txt",
+    "Can't submit solution: Not connected": "${AUTOMINE_ALERT_DIR}/cant_submit_not_connected.txt"
 }


### PR DESCRIPTION
When the "not connected error" message occurs, ethminer is not submitting any
shares and needs to be restarted.

N.B re-run install_systemd_units after updating to this commit