### PR TITLE
Updates configure_xorg.sh

### DIFF
--- a/nvidia/configure_xorg.sh
+++ b/nvidia/configure_xorg.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
-
 # Creates an edid using the instructions here: http://bit.ly/2saRBPy
 
 set -e
 
-function this_dir() {
+this_dir() {
     local script_path="${BASH_SOURCE[0]}"
-    if ([ -h "${script_path}" ]) then
-       while([ -h "${script_path}" ]) do script_path=`readlink "${script_path}"`; done
-       fi
-            pushd . > /dev/null
-            cd $(dirname ${script_path}) > /dev/null
-            script_path=$(pwd);
-            popd  > /dev/null
-            echo $script_path
+    if ([ -h "${script_path}" ])
+    then
+        while([ -h "${script_path}" ])
+        do
+            script_path=`readlink "${script_path}"`;
+        done
+    fi
+    pushd . > /dev/null
+    cd $(dirname ${script_path}) > /dev/null
+    script_path=$(pwd);
+    popd  > /dev/null
+    echo $script_path
 }
 
 # Install edid tools.
@@ -25,16 +28,30 @@ install_edid_tools() {
 
 # Create/Copy edid.bin.
 #
-# If a physical monitor is connected when this command is run, it uses get-edid
-# to create edid.bin, otherwise it copies a pre-generated one from the data
-# directory
+# Args: extract_edid
+#
+# If a physical monitor is connected when this command is run and extract_edid
+# is set, it attempts to use get-edid to create edid.bin.
+#
+# If extract_edid is not set, or the attempt to create the edid fails, it copies
+# a pre-generated edid.bin from the data directory
 ensure_edid_bin() {
+    local extract_edid=$1
     local script_dir=$(this_dir)
     local data_dir=$(dirname $script_dir)/data
-    mkdir -p $HOME/tmp
-    sudo get-edid -m 0 > $HOME/tmp/edid.bin || cp -v $data_dir/edid.bin $HOME/tmp/edid.bin
-    cat $HOME/tmp/edid.bin | edid-decode
-    [ -f /etc/X11/edid.bin ] && sudo cp /etc/X11/edid.bin /etc/X11/edid.bin.bak
+
+    if [[ -n ${extract_edid} ]]
+    then
+        echo "configure_xorg: attempting to create an edid.bin because '${extract_edid}' is set"
+        install_edid_tools
+        mkdir -p $HOME/tmp
+        sudo get-edid -m 0 > $HOME/tmp/edid.bin || cp -v $data_dir/edid.bin $HOME/tmp/edid.bin
+        cat $HOME/tmp/edid.bin | edid-decode
+    else
+        echo "configure_xorg: using the pre-created edid.bin"
+        cp -v $data_dir/edid.bin $HOME/tmp/edid.bin
+    fi
+    [[ -f /etc/X11/edid.bin ]] && sudo cp /etc/X11/edid.bin /etc/X11/edid.bin.bak
     sudo cp -v $HOME/tmp/edid.bin /etc/X11/edid.bin
 }
 
@@ -47,6 +64,11 @@ regenerate_xconfig() {
     sudo nvidia-xconfig -a --cool-bits 28 --custom-edid=DFP-0:/etc/X11/edid.bin --use-edid-dpi --connected-monitor=DFP-0
 }
 
-install_edid_tools
-ensure_edid_bin
+restart_lightdm() {
+    echo "configure_xorg: restarting lightdm to use the new xorg config"
+    sudo service lightdm restart
+}
+
+ensure_edid_bin "$@"
 regenerate_xconfig
+restart_lightdm

--- a/ssh_configure_xorg.sh
+++ b/ssh_configure_xorg.sh
@@ -2,5 +2,9 @@
 # Creates an edid.bin used on Nvidia rigs.
 
 source rsync_scripts.sh
-ssh -t $SSH_USER \~/bin/automine/nvidia/configure_xorg.sh
+
+# Use any argument (.e.g, yes,Y,foo) to attempt to generate the edid.bin.
+#
+# Without an argument, the default pre-configured edid.bin is used
+ssh -t $SSH_USER \~/bin/automine/nvidia/configure_xorg.sh "$@"
 


### PR DESCRIPTION
- defaults to not creating an edid.bin
- allows edid.bin creation to be attempted by specifying any command-line
  argument
- restarts lightdm after the xorg config is changed