### PR TITLE
Rename RIG_IP to RIG_HOST

### DIFF
--- a/INSTALLATION_NOTES.md
+++ b/INSTALLATION_NOTES.md
@@ -19,7 +19,7 @@ mkdir -p ~/var/downloads
 # wget -O ~/var/downloads/amdgpu-pro-17.10-414273.tar.xz  https://www2.ati.com/drivers/linux/ubuntu/amdgpu-pro-17.10-414273.tar.xz
 
 # From Mac
-scp ~/Downloads/amdgpu-pro-17.10-414273.tar.xz ${RIG_USER}@{RIG_IP_ADDRESS:-192.168.11.9}:~/var/downloads/amdgpu-pro-17.10-414273.tar.xz
+scp ~/Downloads/amdgpu-pro-17.10-414273.tar.xz ${RIG_USER}@{RIG_HOST_ADDRESS:-192.168.11.9}:~/var/downloads/amdgpu-pro-17.10-414273.tar.xz
 
 # On Ubuntu
 cd /tmp
@@ -50,7 +50,7 @@ sudo usermod -a -G video $LOGNAME
 # On Mac
 # Copy the AMD SDK download to the linux box
 scp ~/Downloads/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2 \
-    ${RIG_USER}@{RIG_IP_ADDRESS:-192.168.11.9}:~/var/downloads/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2
+    ${RIG_USER}@{RIG_HOST_ADDRESS:-192.168.11.9}:~/var/downloads/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2
 
 # On Ubuntu
 # Install the AMD SDK
@@ -219,7 +219,7 @@ mkdir -p ~/var/downloads
 # wget -O ~/var/downloads/amdgpu-pro-17.10-414273.tar.xz  https://www2.ati.com/drivers/linux/ubuntu/amdgpu-pro-17.10-414273.tar.xz
 
 # From Mac
-scp ~/Downloads/amdgpu-pro-17.10-414273.tar.xz ${RIG_IP_ADDRESS:-192.168.11.9}:~/var/downloads/amdgpu-pro-17.10-414273.tar.xz
+scp ~/Downloads/amdgpu-pro-17.10-414273.tar.xz ${RIG_HOST_ADDRESS:-192.168.11.9}:~/var/downloads/amdgpu-pro-17.10-414273.tar.xz
 
 # On Ubuntu
 cd /tmp

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Because all the remote scripts rsync all the needed files to the rig before doin
 ### Configuration
 Make copies of `cfg/127.0.0.1.sample.sh` and `cfg/127.0.0.1.overclock.sample.json` with your rig's IP address and without `.sample` in the filename. You may have a number of rigs, with a copy of each config file. Be sure to replace all occurences of `FILL_THIS_IN` with something meaningful.
 
-Before running any scripts, set RIG_IP or automine will not know which rig you are working with:
+Before running any scripts, set RIG_HOST or automine will not know which rig you are working with:
 
 ```shell
-export RIG_IP=FILL_THIS_IN
+export RIG_HOST=FILL_THIS_IN
 ```
 
 ### Getting ready to mine

--- a/rsync_scripts.sh
+++ b/rsync_scripts.sh
@@ -2,8 +2,8 @@
 
 source ssh_ensure_env.sh
 ssh ${SSH_USER} -p${SSH_PORT} mkdir -p \~/bin
-cp cfg/$RIG_IP.sh cfg.sh
-[ -f cfg/$RIG_IP.overclock.json ] && cp cfg/$RIG_IP.overclock.json overclock.json
+cp cfg/$RIG_HOST.sh cfg.sh
+[ -f cfg/$RIG_HOST.overclock.json ] && cp cfg/$RIG_HOST.overclock.json overclock.json
 rsync -avz -e "ssh -p ${SSH_PORT}" --del --exclude=cfg/* . ${SSH_USER}:~/bin/automine
 rm cfg.sh overclock.json
 

--- a/ssh_ensure_env.sh
+++ b/ssh_ensure_env.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
-if [ -z ${RIG_IP+x} ]; then
-	echo "RIG_IP is unset. Do the following filling in your rig's IP"
-	echo "export RIG_IP=FILL_THIS_IN"
+if [ -z ${RIG_HOST+x} ]; then
+	echo "RIG_HOST is unset. Do the following filling in your rig's hostname or ip address"
+	echo "export RIG_HOST=FILL_THIS_IN"
 	exit
 fi
-if [ ! -f cfg/${RIG_IP}.sh ]; then
-	echo "File not found: cfg/${RIG_IP}.sh"
+if [ ! -f cfg/${RIG_HOST}.sh ]; then
+	echo "File not found: cfg/${RIG_HOST}.sh"
 	echo "Do the following to create the file:"
-	echo "cp cfg/127.0.0.1.sample.sh cfg/${RIG_IP}.sh"
+	echo "cp cfg/127.0.0.1.sample.sh cfg/${RIG_HOST}.sh"
 	echo "Then edit the file and fill in the relevant values for your rig."
 	echo "After filling in the vaules, run this script again."
 	exit
 fi
 
-source cfg/${RIG_IP}.sh
+source cfg/${RIG_HOST}.sh
 
 # Fail with a useful warning if the deprecated value for $AUTOMINE_ALERT_DIR is set
 if [ -n ${AUTOMINE_ALERT_DIR:=''} ] || [ -z ${AUTOMINE_RUNTIME_DIR} ]; 
@@ -30,7 +30,7 @@ if [ "${USE_PUBLIC:=false}" = true ]; then
 	SSH_PORT=${PUBLIC_SSH_PORT:=0}
 	[ ${SSH_PORT}==0 ] && SSH_PORT=${LOCAL_SSH_PORT:=22}
 else
-	SSH_USER=${RIG_USER}@${RIG_IP}
+	SSH_USER=${RIG_USER}@${RIG_HOST}
 	SSH_PORT=${LOCAL_SSH_PORT:=22}
 fi
 DOWNLOAD_DIR=${HOME}/Downloads/${RIG_TYPE}

--- a/ssh_test_env.sh
+++ b/ssh_test_env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source ssh_ensure_env.sh
-echo "Rig Environment: RIG_IP=${RIG_IP} RIG_USER=${RIG_USER} RIG_TYPE=${RIG_TYPE}"
+echo "Rig Environment: RIG_HOST=${RIG_HOST} RIG_USER=${RIG_USER} RIG_TYPE=${RIG_TYPE}"
 echo "Ethminer Environment: WORKER=${WORKER} WALLET=${WALLET}"
 echo "Build flags: ETHASHCUDA=${ETHASHCUDA}"
 echo "Remote access? USE_PUBLIC=${USE_PUBLIC}"


### PR DESCRIPTION
Changed this env name to make it clear that the cfg files don't have to be
prefixed with an IP address; a domain name works as well.