### PR TITLE
Make the rig configuration directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Most of the scripts are thought for running them from the computer you are worki
 Because all the remote scripts rsync all the needed files to the rig before doing anything, you don't need to keep an up-to-date repository on the rig.
 
 ### Configuration
-Make a copy of `cfg/127.0.0.1.automine_config.sample.json` with your rig's IP address or hostname and without `.sample` in the filename. You may have a number of rigs, with a copy of each config file. Be sure to replace all occurences of `FILL_THIS_IN` with something meaningful.
+Create a directory to hold your rig configuration.  The expected value for this is `<my-home-dir>/.automine/rig_config`.  In this directory, make a copy of `cfg/127.0.0.1.automine_config.sample.json` with your rig's IP address or hostname and without `.sample` in the filename. You may have a number of rigs, with a copy of each config file. Be sure to replace all occurences of `FILL_THIS_IN` with something meaningful.
+
+You can use a different directory instead of `<my-home-dir>/.automine/rig_config`.  When doing so, you must export the path of the directory in the environment variable 'AUTOMINE_CFG_DIR' when running any of the automine commands.
 
 Before running any scripts, set RIG_HOST or automine will not know which rig you are working with:
 

--- a/cfg/README.md
+++ b/cfg/README.md
@@ -1,9 +1,9 @@
 # Rig configuration
 
-This directory should contain files that configure the rigs.
-It's empty apart from some sample files
+This directory contain samples of files that configure the rigs.
+Appropriately named and updated copies of the sample file should be copied to the configuration directory, which defaults to `<my-home-dir>/.automine/rig_config`.  E.g,
 
-- `<myhostname>.automine_config.json` is used to configure the script that sets overclock settings on `myhostname`
+- `<my-home-dir>/.automine/rig_config/<myhostname>.automine_config.json` is used to configure the script that sets overclock settings on `myhostname`
    
 ## Environment
 
@@ -23,7 +23,7 @@ The ethminer section optionally contains a nested environment section.  This spe
 
 ## Overclock configuration
 
-Files that match the pattern `<hostname>.automine_config.json` are used to configure overclocking of nvidia GPUs.
+Files that match the pattern `<myhostname>.automine_config.json` are used to configure overclocking of nvidia GPUs.
 
 The nvidia section contains named json configuration objects that can either
 

--- a/rsync_scripts.sh
+++ b/rsync_scripts.sh
@@ -2,7 +2,7 @@
 
 source ssh_ensure_env.sh
 ssh ${SSH_USER} -p${SSH_PORT} mkdir -p \~/bin
-cp cfg/${RIG_HOST}.automine_config.json automine_config.json
+cp ${AUTOMINE_CFG_PATH} automine_config.json
 rsync -avz -e "ssh -p ${SSH_PORT}" --del --exclude=cfg/* . ${SSH_USER}:~/bin/automine
 rm automine_config.json
 

--- a/ssh_ensure_env.sh
+++ b/ssh_ensure_env.sh
@@ -6,16 +6,26 @@ if [ -z ${RIG_HOST+x} ]; then
 	echo "export RIG_HOST=FILL_THIS_IN"
 	exit
 fi
-if [ ! -f cfg/${RIG_HOST}.automine_config.json ]; then
-	echo "File not found: cfg/${RIG_HOST}.automine_config.json"
+export AUTOMINE_CFG_PATH=${AUTOMINE_CFG_DIR:=${HOME}/.automine/rig_config}/${RIG_HOST}.automine_config.json
+LEGACY_CFG_PATH=cfg/${RIG_HOST}.automine_config.json
+
+if [ ! -f ${AUTOMINE_CFG_PATH} ]; then
+  if [ -f ${LEGACY_CFG_PATH} ]; then
+    echo "File not found: ${AUTOMINE_CFG_PATH}"
+    echo "Instead, it's located at the old location: ${LEGACY_CFG_PATH}"
+    echo "Do the following:"
+    echo "1) create the new config dir at $AUTOMINE_CFG_DIR"
+    echo "2) Move all automine config files at the old location to it"
+  else
+	echo "File not found: ${AUTOMINE_CFG_PATH}"
 	echo "Do the following to create the file:"
-	echo "cp cfg/127.0.0.1.automine_config.json cfg/${RIG_HOST}.automine_config.json"
+	echo "cp cfg/127.0.0.1.automine_config.json ${AUTOMINE_CFG_PATH}"
 	echo "Then edit the file and fill in the relevant values for your rig."
-	echo "After filling in the vaules, run this script again."
+	echo "After filling in the values, run this script again."
+  fi
 	exit
 fi
 
-export AUTOMINE_CFG_PATH=cfg/${RIG_HOST}.automine_config.json
 $(./show_config.py shell_exports)
 
 # Fail with a useful warning if the deprecated value for $AUTOMINE_ALERT_DIR is set


### PR DESCRIPTION
- Also switches the default configuration directory to ~/.automine/rig_config,
  i.e, it's no longer in the git repo

The configuration directory can be altered by modifying the environment variable
AUTOMINE_CFG_DIR

Fixes #67 