### PR TITLE
Implement utility functions as scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ autominer uses the [ethermine](https://ethermine.org), an Ethereum mining pool, 
 
 Automine does its work using a number of different scripts.  It is possible to use the scripts directly, but is more convenient to use them via the single command, `automine`.
 
-__Important__ to initialize this command, please add the following to your `.bash_profile` or your `.bashrc` file
+**Important:** To initialize this command, please add the following to your `.bash_profile` or your `.bashrc` file
 
 ```bash
 
@@ -34,7 +34,10 @@ Once you've added this, restart your shell, and you will have a new command `aut
 
 
 ### About remote scripts
-Most of the scripts are intended to be run from the computer you are working at, which typically is not the mining rig itself.  This is done using `automine remote_run`. E.g., to run the upgrade_system command:
+
+Most of the scripts are intended to be run from the computer you are working at, which typically is not the mining rig itself.  This is done using the `automine remote_run` command. 
+
+E.g., to run the `upgrade_system` command:
 
 ```bash
 RIG_HOST=<hostname-of-rig> automine remote_run upgrade_system
@@ -43,30 +46,110 @@ RIG_HOST=<hostname-of-rig> automine remote_run upgrade_system
 Before it runs the specified command, `automine remote_run` syncs all the files it needs to the rig, so it is not necessary to keep an up-to-date repository on the rigs.
 
 ### Configuration
-Create a directory to hold your rig configuration.  The expected value for this is `<my-home-dir>/.automine/rig_config`.  In this directory, make a copy of `cfg/127.0.0.1.automine_config.sample.json` with your rig's IP address or hostname and without `.sample` in the filename. You may have a number of rigs, with a copy of each config file. Be sure to replace all occurences of `FILL_THIS_IN` with something meaningful.
 
-You can use a different directory instead of `<my-home-dir>/.automine/rig_config`.  When doing so, you must export the path of the directory in the environment variable 'AUTOMINE_CFG_DIR' when running any of the automine commands.
+Create a directory to hold the rig configuration.  This location defaults to this is `$HOME/.automine/rig_config`.
 
-Before running any scripts, set RIG_HOST or automine will not know which rig you are working with:
+In this directory, make a copy of `cfg/127.0.0.1.automine_config.sample.json` with your rig's IP address or hostname and without `.sample` in the filename. You may have a number of rigs, with a copy of each config file. Be sure to replace all occurences of `FILL_THIS_IN` with something meaningful, or remove them if that's more appropriate.
 
-```shell
-export RIG_HOST=FILL_THIS_IN
-```
+You may use an alternate to the default location `$HOME/.automine/rig_config`.  When doing so, you must export the path of the directory in the environment variable 'AUTOMINE_CFG_DIR' when running any of the automine commands.
+
+Every automine command needs to know the hostname of the rig being worked on.  This may be set in a number of ways.
+
+1. Before running any command, export the RIG_HOST hostname
+
+   ```shell
+   export RIG_HOST=<the-rig-host-name>
+   automine remote_run update_bashrc
+   ```
+
+2. Set the RIG_HOST var in the same command-line as the automine command
+
+   ```shell
+   RIG_HOST=<the-rig-host-name> automine remote_run update_bashrc
+   ```
+
+3. Setting the rig hostname using with the -a option of the automine command
+
+   ```shell
+   automine -a <the-rig-host-name> remote_run update_bashrc
+   ```
+
+The rest of this doc assumes that `RIG_HOST` is exported
+
 
 ### Getting ready to mine
 1. `automine remote_run install_driver` will install the Linux driver for your GPU type.
 1. `automine remote_run install_autologin_desktop` will install and configure Xorg, needed to overclock NVIDIA GPUs.
+1. `automine remote_run upgrade_system` will upgrade the system, and potential upgrade the drivers if necessary
 1. `automine remote_run build_ethminer` will install the mining software.
-1. `automine remote_run update_bashrc` will add useful lines to your `.bashrc`.
-1. `automine remote_run install_systemd_units` will set autominer as a system service
+1. `automine remote_run install_systemd_units` will install automine as a user-owned systemd service
 
-You should now be able start automine using `mnr_up`. ethminer runs in a `screen` you can access by entering `mnr_screen`. The escape key for `screen` is set to C-z instead of the default C-a. You can also stop autominer by entering `mnr_down`.
+### Bash shortcuts
+
+`automine remote_run update_bashrc` will add useful lines to `.bashrc`
+
+These lines add functions that can be used during interactive SSH sessions.
+
+E.g the ability to start automine service using `mnr_up`, to access service's screen session using `mnr_screen`, and to stop it using `mnr_down`.
+*N.B.* the escape key for `screen` is set to C-z instead of the default C-a.
+
+Also, it sets up the shell PATH variable so that any of the applicable `automine remote_run` commands can also be re-run on the rig using `automine_run`
+E.g.
+
+```bash
+
+automine_run upgrade_system
+
+```
+
+### Mining
+
+1. `automine remote_run minerctl start` will start the automine systemd service, runs the mining software in a screen session
+
+1. `automine remote_run show_screen` will attach to the automine service's screen session via ssh
 
 ### Overclocking
-1. Run `automine remote_run configure_xorg` to get an `/etc/X11/xorg.conf` with a display for each of your GPUs. It will also restart lightdm for you so that the changes are live.
-1. Enter your overclocking choices to your copy of `cfg/127.0.0.1.automine_config.sample.json`. For Nvidia cards, you can set different overclocks for different card types or for each single card.
-1. Restart the automine service (`mnr_down && mnr_up`) and find your Xorg process and overclock values on the `nvidia-smi` tab.
-1. With the automine service running, run `sudo nvidia/overclock.py` for Nvidia cards or `sudo DISPLAY=:0 amdgpu/overclock.py` for AMD cards, and check that the cards are doing alright.
+
+1. `automine remote_run configure_xorg` will update `/etc/X11/xorg.conf` with a display for each of the nvidia GPUs.
+
+   - It takes of care restarting lightdm; the configuration update is applied immediately
+   - **N.B.** This needs to be done after any hard reboot where the number GPUs changes
+   
+1. Update the overclocking choices your copy of `cfg/127.0.0.1.automine_config.sample.json`. 
+   - For Nvidia cards, you can set different overclocks for different card types.
+   
+1. Use `automine remote_run show_screen` to view the screen session
+
+   - For Nvidia cards, switch to the `nvidia-smi` window and ensure there is an Xorg process for each GPU and note the current power levels
+   - exit the screen session, e.g, using 'C-z d'
+   
+1. `automine remote_run apply_overclocks` to update the GPUS to use the overclock settings
+
+   - Use `automine remote_run show_screen` to view the screen session again, and
+     confirm that mining and the GPUs are OK
+     
+1. `automine remote_run apply_overclocks persist` to make the overclocks persist whenever the machine restarts
+
+    - without the 'persist' argument, the overclocks need to be re-applied after any maintenance reboot.  
+    - **N.B.** do this once the overclock settings are stable
+    
+1. `automine remote_run apply_overclocks transient` applies the overclocks, but
+   removes persistence if it is present
+
+   
+### Maintenance suggestions
+
+1. `automine remote_run upgrade_system` should be run regularly (e.g, weekly) to update the base Ubuntu system.
+   - It's important to pick up security upgrades and compatible driver updates
+   - If the `apt-get update` output indicate that packages have been held back, re-run the upgrade_system command with those packages as arguments.  E.g,:
+     - `automine remote_run upgrade_system <pkg1> <pkg2> ... <pkgn>`
+   - **N.B** This command reboots the rig, so after it is run, the mining software will need to be restarted using `automine remote_run minerctl restart`
+   
+1. `automine remote_run optimize_os_services` should be run at least once
+   - It does a number of useful things, but probably the most important is it install basic intrusion detection packages and updates SSH config settings
+   
+1. `automine remote_run build_ethminer` should be run from time to time to pick up improvements to the mining software
+
 
 ## Troubleshooting
 ### BIOS setup

--- a/_automine.bash.inc
+++ b/_automine.bash.inc
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Installs a function for invoking the automine scripts.
 
-# Add as completions the names of top-level automine scripts that don't begin
-# with '_' (as those are internal) that match the keyword
+# Find the completion list of the names of top-level automine scripts that don't
+# begin with '_' (as those are internal) that match the filter
 __automine_find_completions() {
     local filter=${1:-''}
     local this_dir=$(dirname "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")
@@ -15,24 +15,48 @@ __automine_find_completions() {
     done
 }
 
+# Find the completion list of configured rigs that match the filter
+__automine_find_configured_hosts() {
+    local filter=${1:-''}
+    local cfg_dir=${AUTOMINE_CFG_DIR:=${HOME}/.automine/rig_config}
+    local cfgs=$(ls $cfg_dir/*.automine_config.json)
+    for a_cfg in $cfgs
+    do
+        local remove_prefix=${a_cfg##"${cfg_dir}/"}
+        local remove_ext=${remove_prefix%*.automine_config.json}
+        [[ -z $filter || $remove_ext =~ $filter ]] && echo $remove_ext
+    done
+}
+
 # Implement the bash completion protocol using the __automine_find_* functions
 __automine_complete() {
     local command=$1
     local cur_word=$2
     local last_word=$3
+    if __automine_is_configured_host $last_word
+    then
+        local cur=${COMP_WORDS[COMP_CWORD]}
+        COMPREPLY=($(echo $(__automine_find_completions $cur)))
+    fi
     if [[ $last_word == "automine" ]]
     then
         local cur=${COMP_WORDS[COMP_CWORD]}
         COMPREPLY=($(echo $(__automine_find_completions $cur)))
-
+        COMPREPLY+=('-a')
     fi
     if [[ $last_word == "remote_run" ]]
     then
         local cur=${COMP_WORDS[COMP_CWORD]}
         COMPREPLY=($(echo $(__automine_find_all_remote_subcommands $cur)))
     fi
+    if [[ $last_word == "-a" ]]
+    then
+        local cur=${COMP_WORDS[COMP_CWORD]}
+        COMPREPLY=($(echo $(__automine_find_configured_hosts $cur)))
+    fi
 }
 
+# Find the completion list of remote_run subcommands that match the filter
 __automine_find_all_remote_subcommands() {
     local filter=${1:-''}
     local rig_type_dir=${RIG_TYPE:-''}
@@ -41,6 +65,7 @@ __automine_find_all_remote_subcommands() {
     __automine_list_commands 'common/systemd/*.sh' $filter
 }
 
+# List all automine scripts matching command_glob
 __automine_list_commands() {
     local command_glob=$1
     local filter=${2:-''}
@@ -53,32 +78,93 @@ __automine_list_commands() {
     done
 }
 
-automine() {
-    local this_dir=$(dirname "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")
-    all_commands=($(echo $(__automine_find_completions)))
-    local command=$1
-    if [ "$#" -gt 0 ];
-    then
-        shift
-    fi
-
-    local found=0
-    
+# Determine if a command is a top-level automine command
+__automine_is_command() {
+    local command=${1:-''}
+    local all_commands=($(echo $(__automine_find_completions)))
+    local found=1
     for name in "${all_commands[@]}"; do
         [[ $name == "$command" ]] && {
-            local cmd_script=${this_dir}/automine_${command}.sh
-            PATH=$this_dir:$PATH $cmd_script "$@"
-            found=1
+            found=0
             break
         }
     done
+    return $found
+}
 
-    if (( found == 0 ))
+# Determine if a host is one of the configured hosts
+__automine_is_configured_host() {
+    local host=${1:-''}
+    local all_hosts=($(echo $(__automine_find_configured_hosts)))
+    local found=1
+    for name in "${all_hosts[@]}"; do
+        [[ $name == "$host" ]] && {
+            found=0
+            break
+        }
+    done
+    return $found
+}
+
+# Parse a value for RIG_HOST from the -a option
+__automine_maybe_parse_rig_host_option() {
+    OPTIND=1
+    local options_found=0
+    local opt
+    while getopts ":a:" opt;
+    do
+        options_found=1
+        case $opt in
+            a)
+                if __automine_is_command $OPTARG
+                then
+                    echo "Option -a requires a rig hostname argument." >&2
+                    return 1
+                fi
+                export RIG_HOST=$OPTARG
+                ;;
+            \?)
+                echo "Invalid option: -$OPTARG" >&2
+                return 1
+                ;;
+            :)
+                echo "Option -$OPTARG requires an argument." >&2
+                return 1
+                ;;
+        esac
+    done
+    return 0
+}
+
+# The entry-point function for running automine commands
+automine() {
+    if  __automine_maybe_parse_rig_host_option "$@"
     then
-        echo "Unknown automine sub-command: '$command'"
-        echo "The available sub-commands are:"
-        echo "${all_commands[@]}"
+        # update the args if an option was passed in ..maybe_parse_rig_host_option
+        shift $((OPTIND-1))
+
+        # determine the command to run and make sure its passed the correct
+        # sub-command
+        local command=$1
+        if [ "$#" -gt 0 ];
+        then
+            shift
+        fi
+
+        # run the command if it exists, otherwise report an error
+        if __automine_is_command $command
+        then
+            local this_dir=$(dirname "${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}")
+            local cmd_script=${this_dir}/automine_${command}.sh
+            PATH=$this_dir:$PATH $cmd_script "$@"
+        else
+            local all_commands=($(echo $(__automine_find_completions)))
+            echo "Unknown automine sub-command: '$command'"
+            echo "The available sub-commands are:"
+            echo "${all_commands[@]}"
+        fi
     fi
 }
 
+# register automine for bash completion
 complete -o nospace -F __automine_complete automine

--- a/amdgpu/overclock.py
+++ b/amdgpu/overclock.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """A module that execute commands to overclock nvidia chips.
 
-Prequisites: overclock values should be present in
+Prerequisites: overclock values should be present in
 $HOME/.automine/automine_config.json
 
 """

--- a/amdgpu/overclock.py
+++ b/amdgpu/overclock.py
@@ -119,6 +119,14 @@ def _configure_logger():
             loggers = cfg.get('loggers')
             if '__name__' in loggers:
                 loggers[log_name] = loggers.pop('__name__')
+
+                # add logging to the console if env var is set
+                log_to_console = 'AUTOMINE_LOG_TO_CONSOLE' in os.environ
+                if log_to_console and 'console' in handlers:
+                    logger_handlers = loggers[log_name].get('handlers')
+                    if logger_handlers:
+                        logger_handlers.append('console')
+
             dictConfig(cfg)
     except Exception as err:  # pylint: disable=broad-except
         logging.basicConfig()

--- a/common/apply_overclocks.sh
+++ b/common/apply_overclocks.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Apply the configured overclocks
+#
+# It's also possible to control whether the overclocks are persistent:
+#
+# re-applys the overclocks automatically on unschedule machine restarts
+#
+# $ ./apply_overclocks.sh persist
+#
+# Removes persistence - if the overclocks are being applied automatically on
+# unscheduled machine restarts this is stopped.
+#
+# $ ./apply_overclocks transient
+
+
+apply_overclocks() {
+    local persist=${1:-''}
+    local trigger=~/.automine/var/triggers/overclock_on_restart.txt
+    if [[ $persist == 'persist' ]]
+    then
+        touch $trigger
+    fi
+    if [[ $persist == 'transient' && -f $trigger ]]
+    then
+        rm -v $trigger
+    fi
+    mkdir -p /tmp/automine && cp -v ~/.automine/automine_config.json /tmp/automine
+}
+
+apply_overclocks "$@"

--- a/common/dot_bashrc
+++ b/common/dot_bashrc
@@ -1,34 +1,36 @@
 # Test if the miner screen session is present, switch to it if is.
+
+# include the user bin in the PATH
+PATH=$HOME/bin:$PATH
+
 mnr_screen() {
-    local em_screen=$(screen -ls | grep ethminer | awk {'print $1'})
-    [ -z ${em_screen} ] || screen -D -R
+    automine_run show_screen
 }
 
 # Start the miner in its screen session
 mnr_up() {
-    systemctl --user start automine
+    automine_run minerctl start
 }
 
 # Shutdown the miner and its screen session
 mnr_down() {
     echo "Shutting down the miner"
-    systemctl --user stop automine
+    automine_run minerctl stop
 }
 
 # List the Nvidia PCI bus devices
 mnr_nvidia_devices() {
-    lspci -vvv | grep -A 20 NVIDIA
+    automine_run gpu_info lspci
 }
 
 mnr_nvinfo_mini() {
-    nvidia-smi --query-gpu=index,name,pci.bus,pci.sub_device_id,vbios_version --format=csv  
+    automine_run gpu_info mini
 }
 
 mnr_nvinfo_lots() {
-    nvidia-smi --query-gpu=index,name,pci.sub_device_id,clocks.max.sm,clocks.sm,clocks.max.mem,clocks.mem,power.limit,power.draw,power.min_limit,power.max_limit --format=csv
+    automine_run gpu_info
 }
 
-mnr_overclock_info() {
-   cat ~/.automine/automine_config.json
+mnr_rig_config() {
+    automine_show_config
 }
-

--- a/common/scan_log.py
+++ b/common/scan_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A module that scans standard input for errors.
 
 The log substrings to test the input for are configured in by a json file that
@@ -6,10 +6,7 @@ maps them to the path of the trigger file to be updated when they are detected
 
 """
 
-from __future__ import print_function
-
 from datetime import datetime, timedelta
-import codecs
 import json
 from logging.config import dictConfig
 import logging
@@ -54,7 +51,7 @@ def read_cfg(cfg_path):
         _info(_CFG_MESSAGE.format('FALLBACK_POOL', fallback_pool_host))
         raw_dict = json.load(open(cfg_path))
         cfg_dict = {}
-        for key, value in iter(raw_dict.items()):
+        for key, value in iter(list(raw_dict.items())):
             new_key = key.replace("${FALLBACK_POOL}", fallback_pool_host)
             new_value = value.replace("${AUTOMINE_ALERT_DIR}",
                                       automine_alert_dir)
@@ -92,7 +89,7 @@ def _tracker_path():
 def _print_cfg(scan_cfg):
     """Initialize the log of the scan log."""
     _info(u"tracker_path: {}".format(_tracker_path()))
-    for subst, trigger_path in iter(scan_cfg.items()):
+    for subst, trigger_path in iter(list(scan_cfg.items())):
         _info(u"config: {} <- {}".format(trigger_path, subst))
 
 
@@ -131,7 +128,7 @@ def perform_scan(src, scan_cfg):
         latest_log = _update_log_tracker(now, latest_log, a_line)
 
         # scan for the configured trigger lines
-        for subst, trigger_path in iter(scan_cfg.items()):
+        for subst, trigger_path in iter(list(scan_cfg.items())):
             if a_line.find(subst) == -1:
                 consecutive_zeroes = 0
                 continue
@@ -167,9 +164,9 @@ def _configure_logger():
         log_name = _log_name()
         cfg_path = os.path.join(log_dir, 'logging_config.json')
         with open(cfg_path) as src:
-            cfg = json.load(src, 'utf8')
+            cfg = json.load(src)
             handlers = cfg.get('handlers')
-            for handler in iter(handlers.itervalues()):
+            for handler in iter(handlers.values()):
                 filename = handler.get('filename')
                 if filename:
                     filename = filename.replace('{{AUTOMINE_LOG_DIR}}',
@@ -201,8 +198,7 @@ def main():
         if not os.path.exists(cfg_path):
             _info("No scan_log.json at {}, exiting".format(cfg_path))
             return 1
-        reader = codecs.getreader('utf8')
-        perform_scan(reader(sys.stdin), read_cfg(cfg_path))
+        perform_scan(sys.stdin, read_cfg(cfg_path))
         return 0
     except Exception:  # pylint: disable=broad-except
         _LOG.error('could not perform overclock', exc_info=True)

--- a/common/scan_log.py
+++ b/common/scan_log.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """A module that scans standard input for errors.
 
-The log substrings to test the input for are configured in by a json file that
-maps them to the path of the trigger file to be updated when they are detected
+The substrings that the logfile lines are tested for are configured by a json
+file that maps each test to the path of a trigger file to be updated when the
+test succeeds.
 
 """
 
@@ -201,7 +202,7 @@ def main():
         perform_scan(sys.stdin, read_cfg(cfg_path))
         return 0
     except Exception:  # pylint: disable=broad-except
-        _LOG.error('could not perform overclock', exc_info=True)
+        _LOG.error('could not scan the log output', exc_info=True)
         return 1
 
 

--- a/common/scan_log.py
+++ b/common/scan_log.py
@@ -179,6 +179,14 @@ def _configure_logger():
             loggers = cfg.get('loggers')
             if '__name__' in loggers:
                 loggers[log_name] = loggers.pop('__name__')
+
+                # add logging to the console if env var is set
+                log_to_console = 'AUTOMINE_LOG_TO_CONSOLE' in os.environ
+                if log_to_console and 'console' in handlers:
+                    logger_handlers = loggers[log_name].get('handlers')
+                    if logger_handlers:
+                        logger_handlers.append('console')
+
             dictConfig(cfg)
     except Exception as err:  # pylint: disable=broad-except
         logging.basicConfig()

--- a/common/track_scan_log.py
+++ b/common/track_scan_log.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A module that checks if scan_log is continuing to run.
 
 track_scan_log checks that the tracker file created by scan_log exists and has
@@ -9,7 +9,6 @@ is in use.
 
 """
 
-from __future__ import print_function
 
 from datetime import datetime, timedelta
 import json
@@ -119,9 +118,9 @@ def _configure_logger():
         log_name = _log_name()
         cfg_path = os.path.join(log_dir, 'logging_config.json')
         with open(cfg_path) as src:
-            cfg = json.load(src, 'utf8')
+            cfg = json.load(src)
             handlers = cfg.get('handlers')
-            for handler in iter(handlers.itervalues()):
+            for handler in iter(handlers.values()):
                 filename = handler.get('filename')
                 if filename:
                     filename = filename.replace('{{AUTOMINE_LOG_DIR}}',

--- a/common/track_scan_log.py
+++ b/common/track_scan_log.py
@@ -9,7 +9,6 @@ is in use.
 
 """
 
-
 from datetime import datetime, timedelta
 import json
 import logging
@@ -151,7 +150,7 @@ def main():
         check_the_tracker()
         return 0
     except Exception:  # pylint: disable=broad-except
-        _LOG.error('could not perform overclock', exc_info=True)
+        _LOG.error('could not track the scan log', exc_info=True)
         return 1
 
 

--- a/common/track_scan_log.py
+++ b/common/track_scan_log.py
@@ -131,6 +131,14 @@ def _configure_logger():
             loggers = cfg.get('loggers')
             if '__name__' in loggers:
                 loggers[log_name] = loggers.pop('__name__')
+
+                # add logging to the console if env var is set
+                log_to_console = 'AUTOMINE_LOG_TO_CONSOLE' in os.environ
+                if log_to_console and 'console' in handlers:
+                    logger_handlers = loggers[log_name].get('handlers')
+                    if logger_handlers:
+                        logger_handlers.append('console')
+
             dictConfig(cfg)
     except Exception as err:  # pylint: disable=broad-except
         logging.basicConfig()

--- a/logging_config.json
+++ b/logging_config.json
@@ -5,6 +5,9 @@
         "simple": {
             "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
             "datefmt": "%Y-%m-%d %H:%M:%S"
+        },
+        "syslog": {
+            "format": "%(name)s - %(levelname)s - %(message)s"
         }
     },
 
@@ -23,13 +26,19 @@
             "backupCount": 10,
             "filename": "{{AUTOMINE_LOG_DIR}}/{{__name__}}.log",
             "encoding": "utf-8"
+        },
+        "sys-logger6": {
+            "class": "logging.handlers.SysLogHandler",
+            "address": "/dev/log",
+            "facility": "local6",
+            "formatter": "syslog"
         }
     },
 
     "loggers": {
         "__name__": {
             "level": "INFO",
-            "handlers": ["console", "rotate_16mb"]
+            "handlers": ["sys-logger6", "rotate_16mb"]
         }
     }
 }

--- a/nvidia/gpu_health.py
+++ b/nvidia/gpu_health.py
@@ -98,6 +98,14 @@ def _configure_logger():
             loggers = cfg.get('loggers')
             if '__name__' in loggers:
                 loggers[log_name] = loggers.pop('__name__')
+
+                # add logging to the console if env var is set
+                log_to_console = 'AUTOMINE_LOG_TO_CONSOLE' in os.environ
+                if log_to_console and 'console' in handlers:
+                    logger_handlers = loggers[log_name].get('handlers')
+                    if logger_handlers:
+                        logger_handlers.append('console')
+
             dictConfig(cfg)
     except Exception as err:  # pylint: disable=broad-except
         logging.basicConfig()

--- a/nvidia/gpu_health.py
+++ b/nvidia/gpu_health.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A module that execute commands to confirm the health of the gpus
 
 Whenever a gpu is unhealthy, a trigger file in AUTOMINE_ALERT_DIR is updated.
@@ -6,8 +6,6 @@ Whenever a gpu is unhealthy, a trigger file in AUTOMINE_ALERT_DIR is updated.
 Prequisites: the nvidia-smi tool should be installed
 
 """
-
-from __future__ import print_function
 
 from datetime import datetime
 import json
@@ -45,7 +43,7 @@ def perform_status_check():
     try:
         out_dir = os.environ['AUTOMINE_ALERT_DIR']
         out_path = os.path.join(out_dir, 'failed_gpus.txt')
-        show_gpus = subprocess.check_output(_SHOW_GPUS_CMD.split())
+        show_gpus = subprocess.check_output(_SHOW_GPUS_CMD.split()).decode()
 
         # check if the output indicates that a GPU is 'lost'
         really_bad = _A_REALLY_BAD_WAY_RX.search(show_gpus)
@@ -86,9 +84,9 @@ def _configure_logger():
         log_name = _log_name()
         cfg_path = os.path.join(log_dir, 'logging_config.json')
         with open(cfg_path) as src:
-            cfg = json.load(src, 'utf8')
+            cfg = json.load(src)
             handlers = cfg.get('handlers')
-            for handler in iter(handlers.itervalues()):
+            for handler in iter(handlers.values()):
                 filename = handler.get('filename')
                 if filename:
                     filename = filename.replace('{{AUTOMINE_LOG_DIR}}',

--- a/nvidia/gpu_health.py
+++ b/nvidia/gpu_health.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """A module that execute commands to confirm the health of the gpus
 
-Whenever a gpu is unhealthy, a trigger file in AUTOMINE_ALERT_DIR is updated.
+Whenever a GPU is unhealthy, a trigger file in the AUTOMINE_ALERT_DIR is
+updated.
 
-Prequisites: the nvidia-smi tool should be installed
+Prerequisites: the nvidia-smi tool should be installed
 
 """
 
@@ -65,7 +66,7 @@ def perform_status_check():
 
 
 def _mark_bad_gpu(trigger_path, gpu_index):
-    """Leave a record that a GPU was bad."""
+    """Leave a record indicating that a GPU was bad."""
     now = datetime.utcnow().isoformat() + 'Z'
     with open(trigger_path, 'a') as out:
         print('gpu{:02d}:{}'.format(int(gpu_index), now), file=out)
@@ -111,13 +112,13 @@ def _configure_logger():
 
 
 def main():
-    """The command line entry point """
+    """The command-line entry point"""
     try:
         _configure_logger()
         perform_status_check()
         return 0
     except Exception:  # pylint: disable=broad-except
-        _LOG.error('could not perform overclock', exc_info=True)
+        _LOG.error('could not perform GPU health check', exc_info=True)
         return 1
 
 

--- a/nvidia/gpu_info.sh
+++ b/nvidia/gpu_info.sh
@@ -1,0 +1,19 @@
+#/bin/bash
+# Show info about the NVIDIA gpus on the system
+
+show_info() {
+    local info_type=${1:-''}
+    case $info_type in
+        'lspci')
+            sudo lspci -vvv | grep -A 20 'VGA.*NVIDIA'
+            ;;
+        'mini')
+            nvidia-smi --query-gpu=index,name,pci.bus,pci.sub_device_id,vbios_version --format=csv
+            ;;
+        *)
+            nvidia-smi --query-gpu=index,name,pci.sub_device_id,clocks.max.sm,clocks.sm,clocks.max.mem,clocks.mem,power.limit,power.draw,power.min_limit,power.max_limit --format=csv
+            ;;
+    esac
+}
+
+show_info "$@"

--- a/nvidia/overclock.py
+++ b/nvidia/overclock.py
@@ -113,6 +113,14 @@ def _configure_logger():
             loggers = cfg.get('loggers')
             if '__name__' in loggers:
                 loggers[log_name] = loggers.pop('__name__')
+
+                # add logging to the console if env var is set
+                log_to_console = 'AUTOMINE_LOG_TO_CONSOLE' in os.environ
+                if log_to_console and 'console' in handlers:
+                    logger_handlers = loggers[log_name].get('handlers')
+                    if logger_handlers:
+                        logger_handlers.append('console')
+
             dictConfig(cfg)
     except Exception as err:  # pylint: disable=broad-except
         logging.basicConfig()

--- a/nvidia/overclock.py
+++ b/nvidia/overclock.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A module that execute commands to overclock nvidia chips.
 
 Prequisites: overclock values should be present in ~/.automine/automine_config.json
 or in a file specified as an argument
 
 """
-
-from __future__ import print_function
 
 import json
 import logging
@@ -45,9 +43,10 @@ def perform_overclock(cfgs):
     """Perform the overclock."""
     gpus_with_index = subprocess.check_output(_LIST_GPUS_CMD.split())
     one_gpu_script = _sibling_path('overclock_one_gpu.sh')
-    for (name, sub_device,
-         index) in [l.split(', ') for l in gpus_with_index.splitlines()]:
+    lines = gpus_with_index.splitlines()
+    for (name, sub_device, index) in [l.decode().split(', ') for l in lines]:
         index = index.strip()
+        _LOG.info("name is %s, index is %s", name, index)
         sub_device_spec = 'pci.sub_device_id:' + sub_device
         by_name = cfgs.get(name)
         by_spec = cfgs.get(sub_device_spec)
@@ -58,8 +57,9 @@ def perform_overclock(cfgs):
             the_cfg = by_spec or by_name
             child_env = dict(os.environ)
             child_env['NVD_GPU_INDEX'] = index
-            for env_name, value in iter(the_cfg.items()):
-                child_env["NVD_{0}".format(env_name.upper())] = str(value)
+            for env_name, value in iter(list(the_cfg.items())):
+                child_env["NVD_{0}".format(env_name.upper())] = str.format(
+                    "{}", value)
             headline = "updating gpu{:02d} ({}/{})".format(
                 int(index), name, sub_device_spec)
             _info(
@@ -67,7 +67,7 @@ def perform_overclock(cfgs):
                     one_gpu_script,
                     executable='/bin/bash',
                     env=child_env,
-                    shell=True),
+                    shell=True).decode(),
                 headline=headline)
 
 
@@ -101,9 +101,9 @@ def _configure_logger():
         log_name = _log_name()
         cfg_path = os.path.join(log_dir, 'logging_config.json')
         with open(cfg_path) as src:
-            cfg = json.load(src, 'utf8')
+            cfg = json.load(src)
             handlers = cfg.get('handlers')
-            for handler in iter(handlers.itervalues()):
+            for handler in iter(handlers.values()):
                 filename = handler.get('filename')
                 if filename:
                     filename = filename.replace('{{AUTOMINE_LOG_DIR}}',

--- a/nvidia/overclock.py
+++ b/nvidia/overclock.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """A module that execute commands to overclock nvidia chips.
 
-Prequisites: overclock values should be present in ~/.automine/automine_config.json
-or in a file specified as an argument
+Prerequisites: overclock values should be present in
+~/.automine/automine_config.json or in a file specified as an argument
 
 """
 
@@ -92,8 +92,8 @@ def _cfg_path(argv):
 def _configure_logger():
     """Configures logging
 
-    logging_config.json should have been placed in the directory AUTOMINE_LOG_DIR,
-    to which this process must have read and write access
+    logging_config.json should have been placed in the directory
+    AUTOMINE_LOG_DIR, to which this process must have read and write access
 
     """
     try:

--- a/show_config.py
+++ b/show_config.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A module that execute commands to overclock nvidia chips.
 
 Prequisites: overclock values should be present in ~/.automine/automine_config.json
 
 """
-
-from __future__ import print_function
 
 import json
 import logging
@@ -64,7 +62,7 @@ def _show_ethminer_opts(the_cfg):
     rig_type = _get_sub_cfg('environment', the_cfg)['RIG_TYPE']
     rig_type_opt = [_ETHMINER_RIG_TYPE_OPTS[rig_type]]
     _fmt = _format_ethminer_opt
-    other_opts = [_fmt(key, value) for (key, value) in iter(cfg.iteritems())]
+    other_opts = [_fmt(key, value) for (key, value) in iter(list(cfg.items()))]
     return " ".join(rig_type_opt + other_opts)
 
 
@@ -72,7 +70,7 @@ def _show_shell_exports(the_cfg):
     """Generate text to declare the configured export variables in a bash shell"""
     cfg = _get_sub_cfg('environment', the_cfg)
     as_exports = [
-        "{}={}".format(key, val) for key, val in iter(cfg.iteritems())
+        "{}={}".format(key, val) for key, val in iter(list(cfg.items()))
     ]
     return " ".join(["export"] + as_exports)
 


### PR DESCRIPTION
Uses scripts to implement the `mnr_*` functions.

The existing rig-side mnr_* utility functions are updated to be implemented
using the same scripts to simplify future maintenance

This means that they can easily be invoked from the automine host via automine
remote_run

In addition

- adds a command `remote_run apply_overclocks` that simplifies update of
overclocks from the automine host

- Updates the README.me to show how complete most tasks using automine
  remote_run, and with maintenance suggestions

Follows #85 