### PR TITLE
Correct start restart after admin tasks

### DIFF
--- a/common/build_ethminer.sh
+++ b/common/build_ethminer.sh
@@ -53,12 +53,13 @@ build_ethminer() {
 }
 
 cp_to_bin() {
+    $BIN_DIR/automine_run minerctl stop || /bin/true
     cp -v $REPO_DIR/ethminer/build/ethminer/ethminer $BIN_DIR/ethminer
+    $BIN_DIR/automine_run minerctl restart
 }
 
 add_symlinks() {
     local rig_dir=$(dirname $SCRIPT_DIR)/$RIG_TYPE
-    ln -sf ${rig_dir}/launch_screen_session.sh $BIN_DIR/mine_in_a_screen
     [ -f ${rig_dir}/add_symlinks.sh ] && source ${rig_dir}/add_symlinks.sh
 }
 

--- a/common/upgrade_system.sh
+++ b/common/upgrade_system.sh
@@ -9,7 +9,9 @@ upgrade_system() {
     sudo apt -y dist-upgrade
     sudo apt -y autoremove
     [[ -n additional_pkgs ]] && sudo apt -y install $additional_pkgs
-    sudo reboot
+
+    # trigger a reboot where the automine service restarts automatically
+    date -u +'upgrd:%Y-%m-%dT%H:%M:%SZ' >> ~/.automine/var/triggers/failed_gpus.txt
 }
 
 upgrade_system "$@"


### PR DESCRIPTION
- Stop/Restart the automine service while installing a fresh build
- Enable automatic restart of automine after system_upgrade