### PR TITLE
Add a script that simplifies ssh onto the rig

### DIFF
--- a/automine_ssh.sh
+++ b/automine_ssh.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Open an ssh session on a rig
+
+source automine_sync_rig.sh
+set -u
+ssh $SSH_USER -p${SSH_PORT} "$@"


### PR DESCRIPTION
I.e,  once a rig is configured, you can ssh onto it using

```bash

automine -a <rig-host> ssh

```

This helps when there are many rigs as the <rig-host> values autocomplete